### PR TITLE
Story 0.2.3.2.5: Fix UI layout overflow issues in environment indicator tests

### DIFF
--- a/lib/core/widgets/environment_indicator.dart
+++ b/lib/core/widgets/environment_indicator.dart
@@ -203,7 +203,7 @@ class _FirebaseDebugPanelState extends State<FirebaseDebugPanel> {
     final connectionInfo = FirebaseService.getConnectionInfo();
 
     return Container(
-      width: 250,
+      constraints: const BoxConstraints(maxWidth: 250),
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -213,15 +213,18 @@ class _FirebaseDebugPanelState extends State<FirebaseDebugPanel> {
             children: [
               Icon(Icons.bug_report, color: Colors.white, size: 16),
               const SizedBox(width: 8),
-              Text(
-                'Firebase Debug Panel',
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 14,
-                  fontWeight: FontWeight.bold,
+              Expanded(
+                child: Text(
+                  'Firebase Debug Panel',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 14,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  overflow: TextOverflow.ellipsis,
                 ),
               ),
-              const Spacer(),
+              const SizedBox(width: 8),
               GestureDetector(
                 onTap: () => setState(() => _isExpanded = false),
                 child: Icon(Icons.close, color: Colors.white, size: 16),


### PR DESCRIPTION
## Summary
Fixed UI layout overflow issues in FirebaseDebugPanel widget tests that were causing RenderFlex overflow errors.

## Problem Solved
- **Issue**: RenderFlex overflowed by 107 pixels on the right in debug panel tests
- **Root Cause**: Fixed 250px container width exceeded 218px test constraint
- **Location**: Row widget at line 212 in `environment_indicator.dart`

## Changes Made
- **Replaced fixed width with flexible constraint**: `width: 250` → `constraints: BoxConstraints(maxWidth: 250)`
- **Made text responsive**: Wrapped "Firebase Debug Panel" text in `Expanded` widget
- **Added overflow handling**: Added `TextOverflow.ellipsis` to prevent text clipping
- **Improved spacing**: Added proper spacing between text and close button

## Test Results
- ✅ **All 10/10 environment indicator tests now pass** (was 7/10 before)
- ✅ **Fixed failing tests:**
  - "expands debug panel when tapped"
  - "collapses debug panel when close is tapped"
  - "shows correct environment information in debug panel"
- ✅ **No analyzer warnings** in modified file
- ✅ **Maintains existing functionality** while improving responsiveness

## Technical Details
- **Constraints**: Test environment provides 218px width, panel needed 250px
- **Solution**: Flexible layout adapts to available space while preserving max-width preference
- **Responsive**: Panel works correctly in both constrained test environments and normal app usage

## Acceptance Criteria Met
- [x] All environment indicator tests pass without UI overflow errors
- [x] FirebaseDebugPanel displays correctly in test environment
- [x] Row widget content fits within available horizontal space
- [x] Tests maintain existing functionality while fixing layout issues

🤖 Generated with [Claude Code](https://claude.ai/code)