### PR TITLE
Story 0.3.1.3: Fix UserModel Duplicate Game Prevention Logic

### DIFF
--- a/lib/core/data/models/user_model.dart
+++ b/lib/core/data/models/user_model.dart
@@ -174,8 +174,9 @@ class UserModel with _$UserModel {
 
   /// Add game participation
   UserModel addGame(String gameId, {bool won = false, int score = 0}) {
+    final newGameIds = gameIds.contains(gameId) ? gameIds : [...gameIds, gameId];
     return copyWith(
-      gameIds: [...gameIds, gameId],
+      gameIds: newGameIds,
       gamesPlayed: gamesPlayed + 1,
       gamesWon: won ? gamesWon + 1 : gamesWon,
       totalScore: totalScore + score,


### PR DESCRIPTION
## Summary
Fixes logic bug in `UserModel.addGame()` method where duplicate game IDs were being added to gameIds list instead of being prevented.

## Problem
- The `addGame` method was always adding gameIds without checking for duplicates
- Expected: `['game1', 'game2']` when adding 'game1' again  
- Actual: `['game1', 'game2', 'game1']`
- Test requirement: Stats should still increment even when duplicate game is added

## Solution
- Added duplicate check: `gameIds.contains(gameId) ? gameIds : [...gameIds, gameId]`
- If gameId exists: keep existing gameIds unchanged but still update stats
- If gameId is new: add it to list and update stats

## Test Results
- ✅ All 45 UserModel tests pass
- ✅ Specific failing test now passes: "addGame does not add duplicate game"
- ✅ No regression in existing functionality

## Files Changed
- `lib/core/data/models/user_model.dart` - Fixed duplicate prevention logic

## Related Issue
Fixes #71

🤖 Generated with [Claude Code](https://claude.ai/code)